### PR TITLE
Badge style

### DIFF
--- a/lib/notifications-status-view.js
+++ b/lib/notifications-status-view.js
@@ -17,7 +17,8 @@ module.exports = class NotificationsStatusView {
   }
 
   render () {
-    this.number = document.createElement('div')
+    this.number = document.createElement('span')
+    this.number.classList.add('notifications-count-number')
     this.number.textContent = this.count
 
     this.element = document.createElement('a')
@@ -25,6 +26,7 @@ module.exports = class NotificationsStatusView {
     const s = (this.count === 1 ? '' : 's')
     this.tooltip = atom.tooltips.add(this.element, {title: `${this.count} notification${s}`})
     const span = document.createElement('span')
+    span.classList.add('notifications-count-badge')
     span.appendChild(this.number)
     this.element.appendChild(span)
     this.element.addEventListener('click', this.click)

--- a/styles/notifications-status.less
+++ b/styles/notifications-status.less
@@ -1,0 +1,38 @@
+@import "ui-variables";
+
+// Status Bar --------------------------
+
+.notifications-count-badge {
+  display: inline-block;
+  text-align: center;
+  padding: 0 .25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  line-height: 1.25;
+  font-weight: 600;
+  color: @tool-panel-background-color;
+  border-radius: @component-border-radius;
+  background-color: @text-color-subtle;
+}
+
+// Types -------------------------------
+
+.notifications-count[last-type='fatal'] .notifications-count-badge {
+  background-color: @background-color-error;
+}
+
+.notifications-count[last-type='error'] .notifications-count-badge {
+  background-color: @background-color-error;
+}
+
+.notifications-count[last-type='warning'] .notifications-count-badge {
+  background-color: @background-color-warning;
+}
+
+.notifications-count[last-type='info'] .notifications-count-badge {
+  background-color: @background-color-info;
+}
+
+.notifications-count[last-type='success'] .notifications-count-badge {
+  background-color: @background-color-success;
+}

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -229,7 +229,7 @@ atom-notifications {
 
 // Status Bar --------------------------
 
-.notifications-count span {
+.notifications-count-badge {
   display: inline-block;
   text-align: center;
   padding: 0 .25em;
@@ -247,35 +247,35 @@ atom-notifications {
 atom-notification.fatal {
   .notification(@text-color-error; @background-color-error);
 }
-.notifications-count[last-type='fatal'] span {
+.notifications-count[last-type='fatal'] .notifications-count-badge {
   background-color: @background-color-error;
 }
 
 atom-notification.error {
   .notification(@text-color-error; @background-color-error);
 }
-.notifications-count[last-type='error'] span {
+.notifications-count[last-type='error'] .notifications-count-badge {
   background-color: @background-color-error;
 }
 
 atom-notification.warning {
   .notification(@text-color-warning; @background-color-warning);
 }
-.notifications-count[last-type='warning'] span {
+.notifications-count[last-type='warning'] .notifications-count-badge {
   background-color: @background-color-warning;
 }
 
 atom-notification.info {
   .notification(@text-color-info; @background-color-info);
 }
-.notifications-count[last-type='info'] span {
+.notifications-count[last-type='info'] .notifications-count-badge {
   background-color: @background-color-info;
 }
 
 atom-notification.success {
   .notification(@text-color-success; @background-color-success);
 }
-.notifications-count[last-type='success'] span {
+.notifications-count[last-type='success'] .notifications-count-badge {
   background-color: @background-color-success;
 }
 

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -227,56 +227,27 @@ atom-notifications {
   }
 }
 
-// Status Bar --------------------------
-
-.notifications-count-badge {
-  display: inline-block;
-  text-align: center;
-  padding: 0 .25em;
-  min-width: 1.25em;
-  height: 1.25em;
-  line-height: 1.25;
-  font-weight: 600;
-  color: @tool-panel-background-color;
-  border-radius: @component-border-radius;
-  background-color: @text-color-subtle;
-}
 
 // Types -------------------------------
 
 atom-notification.fatal {
   .notification(@text-color-error; @background-color-error);
 }
-.notifications-count[last-type='fatal'] .notifications-count-badge {
-  background-color: @background-color-error;
-}
 
 atom-notification.error {
   .notification(@text-color-error; @background-color-error);
-}
-.notifications-count[last-type='error'] .notifications-count-badge {
-  background-color: @background-color-error;
 }
 
 atom-notification.warning {
   .notification(@text-color-warning; @background-color-warning);
 }
-.notifications-count[last-type='warning'] .notifications-count-badge {
-  background-color: @background-color-warning;
-}
 
 atom-notification.info {
   .notification(@text-color-info; @background-color-info);
 }
-.notifications-count[last-type='info'] .notifications-count-badge {
-  background-color: @background-color-info;
-}
 
 atom-notification.success {
   .notification(@text-color-success; @background-color-success);
-}
-.notifications-count[last-type='success'] .notifications-count-badge {
-  background-color: @background-color-success;
 }
 
 // Mixins -------------------------------

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -230,13 +230,16 @@ atom-notifications {
 // Status Bar --------------------------
 
 .notifications-count span {
-  padding: 0 @component-padding/3;
-  border: 1px solid @text-color;
-
-  div {
-    display: inline-block;
-    position: relative;
-  }
+  display: inline-block;
+  text-align: center;
+  padding: 0 .25em;
+  min-width: 1.25em;
+  height: 1.25em;
+  line-height: 1.25;
+  font-weight: 600;
+  color: @tool-panel-background-color;
+  border-radius: @component-border-radius;
+  background-color: @text-color-subtle;
 }
 
 // Types -------------------------------
@@ -245,40 +248,35 @@ atom-notification.fatal {
   .notification(@text-color-error; @background-color-error);
 }
 .notifications-count[last-type='fatal'] span {
-  color: @text-color-error;
-  border-color: @background-color-error;
+  background-color: @background-color-error;
 }
 
 atom-notification.error {
   .notification(@text-color-error; @background-color-error);
 }
 .notifications-count[last-type='error'] span {
-  color: @text-color-error;
-  border-color: @background-color-error;
+  background-color: @background-color-error;
 }
 
 atom-notification.warning {
   .notification(@text-color-warning; @background-color-warning);
 }
 .notifications-count[last-type='warning'] span {
-  color: @text-color-warning;
-  border-color: @background-color-warning;
+  background-color: @background-color-warning;
 }
 
 atom-notification.info {
   .notification(@text-color-info; @background-color-info);
 }
 .notifications-count[last-type='info'] span {
-  color: @text-color-info;
-  border-color: @background-color-info;
+  background-color: @background-color-info;
 }
 
 atom-notification.success {
   .notification(@text-color-success; @background-color-success);
 }
 .notifications-count[last-type='success'] span {
-  color: @text-color-success;
-  border-color: @background-color-success;
+  background-color: @background-color-success;
 }
 
 // Mixins -------------------------------


### PR DESCRIPTION
### Description of the Change

This is on top of https://github.com/atom/notifications/pull/181. It changes the styling to look more like a badge.

![screen shot 2018-02-05 at 4 02 45 pm](https://user-images.githubusercontent.com/378023/35792264-99aae3a4-0a8f-11e8-9f44-f4bf44a688e3.png)
![screen shot 2018-02-05 at 4 03 17 pm](https://user-images.githubusercontent.com/378023/35792268-9a567034-0a8f-11e8-8262-9b294809d891.png)
![screen shot 2018-02-05 at 4 03 41 pm](https://user-images.githubusercontent.com/378023/35792267-9a292b92-0a8f-11e8-91c0-1c771fa1924c.png)
![screen shot 2018-02-05 at 4 03 57 pm](https://user-images.githubusercontent.com/378023/35792266-99ff2dc4-0a8f-11e8-81c9-b6f4403ec26f.png)
![screen shot 2018-02-05 at 4 04 27 pm](https://user-images.githubusercontent.com/378023/35792265-99d4ccbe-0a8f-11e8-83d8-6ef33b1e12f6.png)



Other changes:

- [x] Adds classes to the child elements. Makes it easier to change elements in the future.
- [x] Moves the status bar styling to its own `notifications-status.less` file. Since the status-bar is a different place.

### Alternate Designs

It *is* the alternative.

### Benefits

Not sure if there any benefits other than taste. 😉 

### Possible Drawbacks

It might look too strong.

### Applicable Issues

On top of: https://github.com/atom/notifications/pull/181
